### PR TITLE
Scroll to top button added to pages

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -9,6 +9,7 @@ import CallToAction from "./components/CallToAction.jsx";
 import DownloadPlatform from "./components/DownloadPlatform.jsx";
 import AsMentionedOn from "./components/AsMentionedOn.jsx";
 import Documentation from "./components/Docs.jsx";
+import ScrollToTopButton from "./components/ScrollToTop.jsx";
 
 
 const App = () => {
@@ -30,6 +31,7 @@ const App = () => {
       ) : (
         <Documentation />
       )}
+      <ScrollToTopButton />
     </div>
   );
 };

--- a/website/src/components/Docs.jsx
+++ b/website/src/components/Docs.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ChevronDown,Copy, Check ,  ChevronRight, ChevronLeft  , Play, Book, Code, Box, Search, Menu, X, ArrowRight } from 'lucide-react';
+import ScrollToTopButton from './ScrollToTop';
 
 const Documentation = () => {
     const [activeSection, setActiveSection] = useState('getting-started');
@@ -21,8 +22,8 @@ const Documentation = () => {
             <CodeExample 
               title="hello_world.simple"
               code={`Note :  This is your first program! .
-message is "Hello, friends!"
-show(message)`} 
+              message is "Hello, friends!"
+              show(message)`} 
             />
           </SubSection>
         </DocSection>
@@ -616,6 +617,7 @@ oops
               </main>
             </div>
           </div>
+          <ScrollToTopButton/>
         </div>
       );
     };

--- a/website/src/components/ScrollToTop.jsx
+++ b/website/src/components/ScrollToTop.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button after scrolling down 300px
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    isVisible && (
+      <button
+        onClick={scrollToTop}
+        className="fixed bottom-6 right-6 p-3 rounded-full shadow-md bg-gray-800 text-white hover:bg-gray-700 transition"
+        aria-label="Scroll to top"
+      >
+        ↑
+      </button>
+    )
+  );
+};
+
+export default ScrollToTopButton;


### PR DESCRIPTION
# Pull Request Template

## Description
Currently the home page doesn't have any scroll to top button. Adding that will help users to scroll back to top by just one click.

## Related Issue
- Fixes #25 

## Type of Change
Please check the relevant option:
- [] Bug fix
- [x] New feature
- [] Documentation update
- [] Code refactoring
- [ ] Other (please describe)

## Changes Made
Describe the changes you've made in detail:
1. I have added a scroll to top button to bottom right corner of page
2. When clicked on the button the content will be scrolled to top

## Screenshot

<img width="1895" height="901" alt="image" src="https://github.com/user-attachments/assets/7121fa97-8d63-42e7-9afa-9884a3309819" />


## Checklist
- [x] I have tested these changes locally
- [x] My code follows the project's coding style
- [x] I have reviewed my own code
- [x] I have commented my code, particularly in hard-to-understand areas
